### PR TITLE
Support text only questions

### DIFF
--- a/lib/canvas_qti_to_learnosity_converter/convert.rb
+++ b/lib/canvas_qti_to_learnosity_converter/convert.rb
@@ -136,7 +136,7 @@ module CanvasQtiToLearnosityConverter
       rescue CanvasQuestionTypeNotSupportedError
         nil
       end
-    end.compact
+    end
 
     {
       title: clean_title(assessment.attribute("title").value),

--- a/lib/canvas_qti_to_learnosity_converter/convert.rb
+++ b/lib/canvas_qti_to_learnosity_converter/convert.rb
@@ -79,9 +79,9 @@ module CanvasQtiToLearnosityConverter
     type = extract_type(xml)
 
     if FEATURE_TYPES.include?(type)
-      learnosity_type = :feature
+      learnosity_type = "feature"
     else
-      learnosity_type = :question
+      learnosity_type = "question"
     end
 
     question = case type
@@ -122,15 +122,14 @@ module CanvasQtiToLearnosityConverter
     ident = assessment.attribute("ident").value
     assets[ident] = {}
 
-    items = { questions: [], features: [] }
+    items = []
+
     quiz.css("item").each.with_index do |item, index|
       begin
         learnosity_type, quiz_item = convert_item(qti_string: item.to_html)
 
-        items_key = learnosity_type == :question ? :questions : :features
-
-        items[items_key].push(quiz_item.to_learnosity)
-        path = [items_key, items[items_key].count - 1]
+        items.push({type: learnosity_type, data: quiz_item.to_learnosity})
+        path = [items.count - 1, :data]
 
         quiz_item.add_learnosity_assets(assets[ident], path)
       rescue CanvasQuestionTypeNotSupportedError

--- a/lib/canvas_qti_to_learnosity_converter/convert.rb
+++ b/lib/canvas_qti_to_learnosity_converter/convert.rb
@@ -14,6 +14,19 @@ require "canvas_qti_to_learnosity_converter/questions/file_upload"
 require "canvas_qti_to_learnosity_converter/questions/text_only"
 
 module CanvasQtiToLearnosityConverter
+  FEATURE_TYPES = [ :text_only_question ]
+  QUESTION_TYPES = [
+    :multiple_choice_question,
+    :true_false_question,
+    :multiple_answers_question,
+    :short_answer_question,
+    :fill_in_multiple_blanks_question,
+    :multiple_dropdowns_question,
+    :matching_question,
+    :essay_question,
+    :file_upload_question,
+  ]
+
   class CanvasQuestionTypeNotSupportedError < RuntimeError
   end
 

--- a/lib/canvas_qti_to_learnosity_converter/questions/text_only.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/text_only.rb
@@ -1,0 +1,22 @@
+require "canvas_qti_to_learnosity_converter/questions/question"
+
+module CanvasQtiToLearnosityConverter
+  class TextOnlyQuestion < QuizQuestion
+    def to_learnosity
+      {
+        type: "sharedpassage",
+        heading: "",
+        content: extract_stimulus(),
+      }
+    end
+
+    def add_learnosity_assets(assets, path)
+      learnosity = to_learnosity
+      CanvasQtiToLearnosityConverter.add_files_to_assets(
+        assets,
+        path + [:content],
+        learnosity[:content]
+      )
+    end
+  end
+end

--- a/lib/canvas_qti_to_learnosity_converter/version.rb
+++ b/lib/canvas_qti_to_learnosity_converter/version.rb
@@ -1,3 +1,3 @@
 module CanvasQtiToLearnosityConverter
-  VERSION = "1.0.0"
+  VERSION = "2.0.0"
 end

--- a/spec/canvas_qti_to_learnosity_converter_spec.rb
+++ b/spec/canvas_qti_to_learnosity_converter_spec.rb
@@ -233,8 +233,8 @@ RSpec.describe CanvasQtiToLearnosityConverter do
       learnosity = question.to_learnosity
 
       expect(question_type).to be :feature
-      expect(learnosity[:type]).to eq "clozetext"
-      expect(learnosity[:content]).to eq "<div><p>Roses are {{response}}, violets are {{response}}</p></div>"
+      expect(learnosity[:type]).to eq "sharedpassage"
+      expect(learnosity[:content]).to eq "<div><p>This is text. Do with it what you will.</p></div>"
     end
   end
 
@@ -246,7 +246,8 @@ RSpec.describe CanvasQtiToLearnosityConverter do
 
       expect(result[:title]).to eql("All Questions")
       expect(result[:ident]).to eql("i68e7925af6a9e291012ad7e532e56c0b")
-      expect(result[:items].size).to eql 9
+      expect(result[:items][:questions].size).to eql 9
+      expect(result[:items][:features].size).to eql 2
     end
   end
 

--- a/spec/canvas_qti_to_learnosity_converter_spec.rb
+++ b/spec/canvas_qti_to_learnosity_converter_spec.rb
@@ -3,10 +3,11 @@ RSpec.describe CanvasQtiToLearnosityConverter do
     it "handles a basic multiple choice question" do
       qti_file = File.new("spec/fixtures/multiple_choice.qti.xml")
       qti = qti_file.read
-      question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
+      question_type, question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
 
       learnosity = question.to_learnosity
 
+      expect(question_type).to be :question
       expect(learnosity[:type]).to eq "mcq"
       expect(learnosity[:stimulus]).to eq "<div><p>Test Multiple Choice, a is to?</p></div>"
 
@@ -37,10 +38,11 @@ RSpec.describe CanvasQtiToLearnosityConverter do
     it "handles a basic true false question" do
       qti_file = File.new("spec/fixtures/true_false.qti.xml")
       qti = qti_file.read
-      question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
+      question_type, question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
 
       learnosity = question.to_learnosity
 
+      expect(question_type).to be :question
       expect(learnosity[:type]).to eq "mcq"
       expect(learnosity[:stimulus]).to eq "<div><p>The grand canyon is deep?</p></div>"
 
@@ -60,7 +62,7 @@ RSpec.describe CanvasQtiToLearnosityConverter do
     it "handles a basic multiple answer question" do
       qti_file = File.new("spec/fixtures/multiple_answer.qti.xml")
       qti = qti_file.read
-      question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
+      question_type, question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
 
       learnosity = question.to_learnosity
 
@@ -88,10 +90,11 @@ RSpec.describe CanvasQtiToLearnosityConverter do
     it "handles a basic matching question" do
       qti_file = File.new("spec/fixtures/matching.qti.xml")
       qti = qti_file.read
-      question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
+      question_type, question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
 
       learnosity = question.to_learnosity
 
+      expect(question_type).to be :question
       expect(learnosity[:type]).to eq "association"
       expect(learnosity[:stimulus]).to eq "<div><p>matching question</p></div>"
       expect(learnosity[:stimulus_list]).to eq([
@@ -117,7 +120,7 @@ RSpec.describe CanvasQtiToLearnosityConverter do
     it "handles a basic multiple dropdowns question" do
       qti_file = File.new("spec/fixtures/multiple_dropdowns.qti.xml")
       qti = qti_file.read
-      question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
+      question_type, question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
 
       learnosity = question.to_learnosity
 
@@ -142,10 +145,11 @@ RSpec.describe CanvasQtiToLearnosityConverter do
     it "handles a basic short answer question" do
       qti_file = File.new("spec/fixtures/short_answer.qti.xml")
       qti = qti_file.read
-      question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
+      question_type, question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
 
       learnosity = question.to_learnosity
 
+      expect(question_type).to be :question
       expect(learnosity[:type]).to eq "shorttext"
       expect(learnosity[:stimulus]).to eq "<div><p>Fill in the</p></div>"
       expect(learnosity[:validation]).to eq({
@@ -164,10 +168,11 @@ RSpec.describe CanvasQtiToLearnosityConverter do
     it "handles a basic essay question" do
       qti_file = File.new("spec/fixtures/essay.qti.xml")
       qti = qti_file.read
-      question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
+      question_type, question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
 
       learnosity = question.to_learnosity
 
+      expect(question_type).to be :question
       expect(learnosity[:type]).to eq "longtextV2"
       expect(learnosity[:stimulus]).to eq "<div><p>What do you think?</p></div>"
     end
@@ -177,10 +182,11 @@ RSpec.describe CanvasQtiToLearnosityConverter do
     it "handles a basic file upload question" do
       qti_file = File.new("spec/fixtures/file_upload.qti.xml")
       qti = qti_file.read
-      question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
+      question_type, question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
 
       learnosity = question.to_learnosity
 
+      expect(question_type).to be :question
       expect(learnosity[:type]).to eq "fileupload"
       expect(learnosity[:stimulus]).to eq "<div><p>Give me a good file.</p></div>"
     end
@@ -190,10 +196,11 @@ RSpec.describe CanvasQtiToLearnosityConverter do
     it "handles a basic fill the blanks question" do
       qti_file = File.new("spec/fixtures/fill_blanks.qti.xml")
       qti = qti_file.read
-      question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
+      question_type, question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
 
       learnosity = question.to_learnosity
 
+      expect(question_type).to be :question
       expect(learnosity[:type]).to eq "clozetext"
       expect(learnosity[:stimulus]).to eq ""
       expect(learnosity[:template]).to eq "<div><p>Roses are {{response}}, violets are {{response}}</p></div>"
@@ -213,6 +220,21 @@ RSpec.describe CanvasQtiToLearnosityConverter do
           {"value"=>["RED", "blue"]},
         ]
       })
+    end
+  end
+
+
+  describe "Text Only Question" do
+    it "handles a basic text only question" do
+      qti_file = File.new("spec/fixtures/text_only.qti.xml")
+      qti = qti_file.read
+      question_type, question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
+
+      learnosity = question.to_learnosity
+
+      expect(question_type).to be :feature
+      expect(learnosity[:type]).to eq "clozetext"
+      expect(learnosity[:content]).to eq "<div><p>Roses are {{response}}, violets are {{response}}</p></div>"
     end
   end
 
@@ -236,4 +258,5 @@ RSpec.describe CanvasQtiToLearnosityConverter do
       expect(result[:assessments].first[:title]).to eql("All Questions")
     end
   end
+
 end

--- a/spec/fixtures/text_only.qti.xml
+++ b/spec/fixtures/text_only.qti.xml
@@ -1,0 +1,23 @@
+<item ident="i353f8ee73bfc78d475690f4532f755e6" title="Question">
+  <itemmetadata>
+    <qtimetadata>
+      <qtimetadatafield>
+        <fieldlabel>question_type</fieldlabel>
+        <fieldentry>text_only_question</fieldentry>
+      </qtimetadatafield>
+      <qtimetadatafield>
+        <fieldlabel>points_possible</fieldlabel>
+        <fieldentry>0</fieldentry>
+      </qtimetadatafield>
+      <qtimetadatafield>
+        <fieldlabel>assessment_question_identifierref</fieldlabel>
+        <fieldentry>if47b767d37e06559ff801f2d253307ba</fieldentry>
+      </qtimetadatafield>
+    </qtimetadata>
+  </itemmetadata>
+  <presentation>
+    <material>
+      <mattext texttype="text/html">&lt;div&gt;&lt;p&gt;This is text. Do with it what you will.&lt;/p&gt;&lt;/div&gt;</mattext>
+    </material>
+  </presentation>
+</item>


### PR DESCRIPTION
This PR adds text only questions, which requires returning features as well as questions in the items. This breaking change to the api bumps the version to 2.0.0