### PR TITLE
Canvas quiz import fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/
 
 .byebug_history
 

--- a/canvas_qti_to_learnosity_converter.gemspec
+++ b/canvas_qti_to_learnosity_converter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.3"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/canvas_qti_to_learnosity_converter/convert.rb
+++ b/lib/canvas_qti_to_learnosity_converter/convert.rb
@@ -83,8 +83,8 @@ module CanvasQtiToLearnosityConverter
   end
 
   def self.add_files_to_assets(assets, path, text)
-    text.scan(/%24IMS-CC-FILEBASE%24\/([^"]+)/).flatten.each do |asset_path|
-      decoded_path = URI.unescape(asset_path)
+    text.scan(/(%24|\$)IMS-CC-FILEBASE\1\/([^"]+)/) do |_delimiter, asset_path|
+      decoded_path = CGI.unescape(asset_path)
       assets[decoded_path] ||= []
       assets[decoded_path].push(path)
     end

--- a/lib/canvas_qti_to_learnosity_converter/convert.rb
+++ b/lib/canvas_qti_to_learnosity_converter/convert.rb
@@ -132,9 +132,11 @@ module CanvasQtiToLearnosityConverter
 
     quiz.css("item").each.with_index do |item, index|
       begin
+        item_title = item.attribute("title").value
         learnosity_type, quiz_item = convert_item(qti_string: item.to_html)
 
         item = {
+          title: item_title,
           type: learnosity_type,
           data: quiz_item.to_learnosity,
           dynamic_content_data: quiz_item.dynamic_content_data()

--- a/lib/canvas_qti_to_learnosity_converter/questions/calculated.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/calculated.rb
@@ -28,6 +28,7 @@ module CanvasQtiToLearnosityConverter
       {
         "scoring_type" => "exactMatch",
         "valid_response" => {
+          "score" => extract_points_possible,
           "value" => [[{
             "method" => "equivValue",
             "value" => "{{var:answer}}\\pm#{pm}"

--- a/lib/canvas_qti_to_learnosity_converter/questions/essay.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/essay.rb
@@ -6,6 +6,9 @@ module CanvasQtiToLearnosityConverter
       {
         type: "longtextV2",
         stimulus: extract_stimulus(),
+        validation: {
+          max_score: extract_points_possible,
+        },
       }
     end
 

--- a/lib/canvas_qti_to_learnosity_converter/questions/file_upload.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/file_upload.rb
@@ -6,6 +6,9 @@ module CanvasQtiToLearnosityConverter
       {
         type: "fileupload",
         stimulus: extract_stimulus(),
+        validation: {
+          max_score: extract_points_possible,
+        },
         allow_pdf: true,
         allow_jpg: true,
         allow_gif: true,

--- a/lib/canvas_qti_to_learnosity_converter/questions/fill_the_blanks.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/fill_the_blanks.rb
@@ -42,7 +42,8 @@ module CanvasQtiToLearnosityConverter
       create_responses(responses, 0, all_responses, [])
 
       {
-        "scoring_type" => "partialMatch",
+        "scoring_type" => "partialMatchV2",
+        "rounding" => "none",
         "valid_response" => all_responses.shift,
         "alt_responses" => all_responses
       }
@@ -50,7 +51,7 @@ module CanvasQtiToLearnosityConverter
 
     def create_responses(blank_responses, depth, result, current_response)
       if depth == blank_responses.count
-        result.push({ "value" => current_response })
+        result.push({ "score" => extract_points_possible, "value" => current_response })
         return
       end
 

--- a/lib/canvas_qti_to_learnosity_converter/questions/matching.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/matching.rb
@@ -4,19 +4,20 @@ module CanvasQtiToLearnosityConverter
   class MatchingQuestion < QuizQuestion
     def to_learnosity
       {
-        type: "association",
+        type: "clozedropdown",
         stimulus: extract_stimulus(),
-        stimulus_list: extract_stimulus_list(),
+        template: extract_template(),
         validation: extract_validation(),
         possible_responses: extract_responses(),
         duplicate_responses: true,
+        shuffle_options: true,
       }
     end
 
-    def extract_stimulus_list()
+    def extract_template()
       @xml.css("item > presentation > response_lid > material > mattext").map do |node|
-        extract_mattext(node)
-      end
+        "<p>#{extract_mattext(node)} {{response}}</p>"
+      end.join("\n")
     end
 
     def extract_response_idents()
@@ -48,18 +49,20 @@ module CanvasQtiToLearnosityConverter
       end.flatten
 
       {
-        "scoring_type" => "partialMatch",
+        "scoring_type" => "partialMatchV2",
+        "rounding" => "none",
         "valid_response" => {
-          "value" => valid_responses
+          "value" => valid_responses,
+          "score" => extract_points_possible,
         }
       }
     end
 
     def extract_responses()
-      response_node = @xml.css("item > presentation > response_lid").first
-
-      response_node.css("response_label mattext").map do |node|
-        extract_mattext(node)
+      @xml.css("item > presentation > response_lid").map do |response|
+        response.css("response_label mattext").map do |node|
+          extract_mattext(node)
+        end
       end
     end
 

--- a/lib/canvas_qti_to_learnosity_converter/questions/multiple_choice.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/multiple_choice.rb
@@ -30,6 +30,7 @@ module CanvasQtiToLearnosityConverter
         "scoring_type" => "exactMatch",
         "valid_response" => {
           "value" => [correct_value],
+          "score" => extract_points_possible,
         },
       }
     end
@@ -81,8 +82,13 @@ module CanvasQtiToLearnosityConverter
                                    and > varequal')
       alt_responses = correct_condition.map(&:text)
       {
-        "scoring_type" => "partialMatch",
-        "alt_responses" => alt_responses,
+        "scoring_type" => "partialMatchV2",
+        "rounding" => "none",
+        "penalty" => extract_points_possible,
+        "valid_response" => {
+          "score" => extract_points_possible,
+          "value" => alt_responses,
+        },
       }
     end
   end

--- a/lib/canvas_qti_to_learnosity_converter/questions/multiple_dropdowns.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/multiple_dropdowns.rb
@@ -28,9 +28,11 @@ module CanvasQtiToLearnosityConverter
       end.flatten
 
       {
-        "scoring_type" => "partialMatch",
+        "scoring_type" => "partialMatchV2",
+        "rounding" => "none",
         "valid_response" => {
           "value" => valid_responses,
+          "score" => extract_points_possible,
         }
       }
     end

--- a/lib/canvas_qti_to_learnosity_converter/questions/numerical.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/numerical.rb
@@ -41,6 +41,7 @@ module CanvasQtiToLearnosityConverter
           "value" => [{
             "method" => "equivValue",
             "value" => "#{bounds[:center]}\\pm#{bounds[:pm]}",
+            "score" => extract_points_possible,
           }]
         }
       end

--- a/lib/canvas_qti_to_learnosity_converter/questions/question.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/question.rb
@@ -14,6 +14,12 @@ module CanvasQtiToLearnosityConverter
       extract_mattext(mattext)
     end
 
+    def extract_points_possible
+      @xml.css(%{ item > itemmetadata > qtimetadata >
+        qtimetadatafield > fieldlabel:contains("points_possible")})
+        &.first&.next&.text&.to_f || 1.0
+    end
+
     def extract_mattext(mattext_node)
       mattext_node.content
     end

--- a/lib/canvas_qti_to_learnosity_converter/questions/short_answer.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/short_answer.rb
@@ -20,11 +20,11 @@ module CanvasQtiToLearnosityConverter
     def extract_validation()
       correct_responses = @xml.css('item > resprocessing >
         respcondition[continue="No"] > conditionvar > varequal')
-      correct_response = { "value" => correct_responses.shift.text }
+      correct_response = { "value" => correct_responses.shift.text, "score" => extract_points_possible}
       {
         "scoring_type" => "exactMatch",
         "valid_response" => correct_response,
-        "alt_responses" => correct_responses.map { |res| { "value" => res.text } }
+        "alt_responses" => correct_responses.map { |res| { "value" => res.text, "score" => extract_points_possible } }
       }
     end
 

--- a/lib/canvas_qti_to_learnosity_converter/version.rb
+++ b/lib/canvas_qti_to_learnosity_converter/version.rb
@@ -1,3 +1,3 @@
 module CanvasQtiToLearnosityConverter
-  VERSION = "2.3.0"
+  VERSION = "2.4.0"
 end

--- a/spec/canvas_qti_to_learnosity_converter_spec.rb
+++ b/spec/canvas_qti_to_learnosity_converter_spec.rb
@@ -34,6 +34,34 @@ RSpec.describe CanvasQtiToLearnosityConverter do
     end
   end
 
+  describe "assets" do
+    it "detects assets" do
+      qti_file = File.new("spec/fixtures/assets.qti.xml")
+      qti = qti_file.read
+      question_type, question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
+      assets = {}
+      question.add_learnosity_assets(assets, [:asset_path])
+
+      expect(assets).to eq({
+        "Uploaded Media/apple-1.jpeg" => [[:asset_path, :stimulus]],
+        "Uploaded Media/apple-2.jpeg" => [[:asset_path, :stimulus]],
+      })
+    end
+    it "detects newer style assets" do
+      qti_file = File.new("spec/fixtures/assets_new_style.qti.xml")
+      qti = qti_file.read
+      question_type, question = CanvasQtiToLearnosityConverter.convert_item(qti_string: qti)
+      assets = {}
+      question.add_learnosity_assets(assets, [:asset_path])
+
+      expect(assets).to eq({
+        "Uploaded Media/apple-1.jpeg" => [[:asset_path, :stimulus]],
+        "Uploaded Media/apple-2.jpeg" => [[:asset_path, :stimulus]],
+      })
+
+    end
+  end
+
   describe "True False" do
     it "handles a basic true false question" do
       qti_file = File.new("spec/fixtures/true_false.qti.xml")
@@ -284,7 +312,7 @@ RSpec.describe CanvasQtiToLearnosityConverter do
       expect(learnosity[:validation]).to eq({
         "scoring_type"=>"exactMatch",
         "valid_response" => {
-          "value" => [[{"method"=>"equivSymbolic", "value"=>"{{var:answer}}\\pm0.23"}]]
+          "value" => [[{"method"=>"equivValue", "value"=>"{{var:answer}}\\pm0.23"}]]
         }
       })
     end
@@ -294,7 +322,8 @@ RSpec.describe CanvasQtiToLearnosityConverter do
     it "handles qti strings" do
       qti_string = CanvasQtiToLearnosityConverter.
         read_file(fixture_path("all_question_types.qti.xml"))
-      result = CanvasQtiToLearnosityConverter.convert(qti_string, {})
+
+      result = CanvasQtiToLearnosityConverter.convert(qti_string, {}, {})
 
       expect(result[:title]).to eql("All Questions")
       expect(result[:ident]).to eql("i68e7925af6a9e291012ad7e532e56c0b")

--- a/spec/canvas_qti_to_learnosity_converter_spec.rb
+++ b/spec/canvas_qti_to_learnosity_converter_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe CanvasQtiToLearnosityConverter do
         "scoring_type" => "exactMatch",
         "valid_response" => {
           "value" => ["1487"],
+          "score" => 3.0,
         }
       })
     end
@@ -81,7 +82,7 @@ RSpec.describe CanvasQtiToLearnosityConverter do
 
       expect(learnosity[:validation]).to eq({
         "scoring_type" => "exactMatch",
-        "valid_response" => { "value"=>["7161"] },
+        "valid_response" => { "value"=>["7161"], "score"=>3.0 },
       })
     end
   end
@@ -106,8 +107,13 @@ RSpec.describe CanvasQtiToLearnosityConverter do
       ]
 
       expect(learnosity[:validation]).to eq({
-        "scoring_type"=>"partialMatch",
-        "alt_responses"=>["9078", "5022", "9720"]
+        "scoring_type"=>"partialMatchV2",
+        "rounding"=>"none",
+        "penalty"=>3,
+        "valid_response"=>{
+          "score"=>3.0,
+          "value"=>["9078", "5022", "9720"],
+        },
       })
 
       expect(learnosity[:multiple_responses]).to eq true
@@ -123,21 +129,19 @@ RSpec.describe CanvasQtiToLearnosityConverter do
       learnosity = question.to_learnosity
 
       expect(question_type).to eq "question"
-      expect(learnosity[:type]).to eq "association"
+      expect(learnosity[:type]).to eq "clozedropdown"
       expect(learnosity[:stimulus]).to eq "<div><p>matching question</p></div>"
-      expect(learnosity[:stimulus_list]).to eq([
-        "left 1", "left 2", "left 3"
-      ])
+      expect(learnosity[:template]).to eq("<p>left 1 {{response}}</p>\n<p>left 2 {{response}}</p>\n<p>left 3 {{response}}</p>")
 
       expect(learnosity[:validation]).to eq({
-        "scoring_type" => "partialMatch",
-        "valid_response" => {
-          "value" => ["right 1", "right 2", "right 3"],
-        }
+         "rounding"=>"none",
+         "scoring_type"=>"partialMatchV2",
+         "valid_response"=>{"score"=>3.0, "value"=>["right 1", "right 2", "right 3"]}
       })
 
+      possible_responses = ["right 1", "right 2", "right 3", "wrong 1", "wrong 2", "wrong 3"]
       expect(learnosity[:possible_responses]).to eq([
-        "right 1", "right 2", "right 3", "wrong 1", "wrong 2", "wrong 3"
+        possible_responses, possible_responses, possible_responses,
       ])
 
       expect(learnosity[:duplicate_responses]).to eq(true)
@@ -156,8 +160,10 @@ RSpec.describe CanvasQtiToLearnosityConverter do
       expect(learnosity[:stimulus]).to eq ""
       expect(learnosity[:template]).to eq "<div><p>multiple dropdowns {{response}} {{response}}</p></div>"
       expect(learnosity[:validation]).to eq({
-        "scoring_type" => "partialMatch",
+        "scoring_type" => "partialMatchV2",
+        "rounding" => "none",
         "valid_response" => {
+          "score" => 3.0,
           "value" => ["right", "right"],
         }
       })
@@ -182,11 +188,11 @@ RSpec.describe CanvasQtiToLearnosityConverter do
       expect(learnosity[:stimulus]).to eq "<div><p>Fill in the</p></div>"
       expect(learnosity[:validation]).to eq({
         "scoring_type"=>"exactMatch",
-        "valid_response"=>{"value"=>"Blank"},
+        "valid_response"=>{"value"=>"Blank", "score"=>2.0},
         "alt_responses"=>[
-          {"value"=>"blank"},
-          {"value"=>"space"},
-          {"value"=>"empty spot"},
+          {"value"=>"blank", "score"=>2.0},
+          {"value"=>"space", "score"=>2.0},
+          {"value"=>"empty spot", "score"=>2.0},
         ]
       })
     end
@@ -233,19 +239,21 @@ RSpec.describe CanvasQtiToLearnosityConverter do
       expect(learnosity[:stimulus]).to eq ""
       expect(learnosity[:template]).to eq "<div><p>Roses are {{response}}, violets are {{response}}</p></div>"
       expect(learnosity[:validation]).to eq({
-        "scoring_type" => "partialMatch",
+        "scoring_type" => "partialMatchV2",
+        "rounding" => "none",
         "valid_response" => {
-          "value"=>["Red", "Blue"]
+          "value"=>["Red", "Blue"],
+          "score"=>2.0,
         },
         "alt_responses" => [
-          {"value"=>["Red", "BLUE"]},
-          {"value"=>["Red", "blue"]},
-          {"value"=>["red", "Blue"]},
-          {"value"=>["red", "BLUE"]},
-          {"value"=>["red", "blue"]},
-          {"value"=>["RED", "Blue"]},
-          {"value"=>["RED", "BLUE"]},
-          {"value"=>["RED", "blue"]},
+          {"value"=>["Red", "BLUE"], "score"=>2.0},
+          {"value"=>["Red", "blue"], "score"=>2.0},
+          {"value"=>["red", "Blue"], "score"=>2.0},
+          {"value"=>["red", "BLUE"], "score"=>2.0},
+          {"value"=>["red", "blue"], "score"=>2.0},
+          {"value"=>["RED", "Blue"], "score"=>2.0},
+          {"value"=>["RED", "BLUE"], "score"=>2.0},
+          {"value"=>["RED", "blue"], "score"=>2.0},
         ]
       })
     end
@@ -279,13 +287,13 @@ RSpec.describe CanvasQtiToLearnosityConverter do
       expect(learnosity[:validation]).to eq({
         "scoring_type"=>"exactMatch",
         "valid_response" => {
-          "value" => [{"method"=>"equivValue", "value"=>"1.2\\pm0.05"}]
+          "value" => [{"method"=>"equivValue", "value"=>"1.2\\pm0.05", "score"=>2.0}]
         },
         "alt_responses"=> [
-          { "value"=>[{ "method"=> "equivValue", "value"=>"1.0\\pm0.1" }] },
-          { "value"=>[{ "method"=> "equivValue", "value"=>"2.0\\pm0.1" }] },
-          { "value"=>[{ "method"=> "equivValue", "value"=>"3.0\\pm0.1" }] },
-          { "value"=>[{ "method"=> "equivValue", "value"=>"8.0\\pm3.0" }] },
+          { "value"=>[{ "method"=> "equivValue", "value"=>"1.0\\pm0.1", "score"=>2.0 }] },
+          { "value"=>[{ "method"=> "equivValue", "value"=>"2.0\\pm0.1", "score"=>2.0 }] },
+          { "value"=>[{ "method"=> "equivValue", "value"=>"3.0\\pm0.1", "score"=>2.0 }] },
+          { "value"=>[{ "method"=> "equivValue", "value"=>"8.0\\pm3.0", "score"=>2.0 }] },
         ]
       })
     end
@@ -312,6 +320,7 @@ RSpec.describe CanvasQtiToLearnosityConverter do
       expect(learnosity[:validation]).to eq({
         "scoring_type"=>"exactMatch",
         "valid_response" => {
+          "score" => 3.0,
           "value" => [[{"method"=>"equivValue", "value"=>"{{var:answer}}\\pm0.23"}]]
         }
       })

--- a/spec/fixtures/assets.qti.xml
+++ b/spec/fixtures/assets.qti.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment ident="geee6bbefe689398193e27701c896d7b6" title="Quiz with image">
+    <qtimetadata>
+      <qtimetadatafield>
+        <fieldlabel>cc_maxattempts</fieldlabel>
+        <fieldentry>1</fieldentry>
+      </qtimetadatafield>
+    </qtimetadata>
+    <section ident="root_section">
+      <item ident="g43b76ab71793b36116ffb6e7fbad9b6d" title="Question">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_choice_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>points_possible</fieldlabel>
+              <fieldentry>1.0</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>original_answer_ids</fieldlabel>
+              <fieldentry>8889,1600,6475,1164</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>assessment_question_identifierref</fieldlabel>
+              <fieldentry>g6d35a948686cc237529cbe501ca1bf50</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material>
+            <mattext texttype="text/html">
+                &lt;div&gt;&lt;p&gt;&lt;img src="%24IMS-CC-FILEBASE%24/Uploaded%20Media/apple-1.jpeg" alt="apple-1.jpeg"&gt;&lt;/p&gt;&lt;/div&gt;
+                &lt;div&gt;&lt;p&gt;&lt;img src="%24IMS-CC-FILEBASE%24/Uploaded%20Media/apple-2.jpeg" alt="apple-2.jpeg"&gt;&lt;/p&gt;&lt;/div&gt;
+            </mattext>
+          </material>
+          <response_lid ident="response1" rcardinality="Single">
+            <render_choice>
+              <response_label ident="8889">
+                <material>
+                  <mattext texttype="text/plain">Correct</mattext>
+                </material>
+              </response_label>
+              <response_label ident="1600">
+                <material>
+                  <mattext texttype="text/plain">Wrong</mattext>
+                </material>
+              </response_label>
+              <response_label ident="6475">
+                <material>
+                  <mattext texttype="text/plain"></mattext>
+                </material>
+              </response_label>
+              <response_label ident="1164">
+                <material>
+                  <mattext texttype="text/plain"></mattext>
+                </material>
+              </response_label>
+            </render_choice>
+          </response_lid>
+        </presentation>
+        <resprocessing>
+          <outcomes>
+            <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/>
+          </outcomes>
+          <respcondition continue="No">
+            <conditionvar>
+              <varequal respident="response1">8889</varequal>
+            </conditionvar>
+            <setvar action="Set" varname="SCORE">100</setvar>
+          </respcondition>
+        </resprocessing>
+      </item>
+    </section>
+  </assessment>
+</questestinterop>

--- a/spec/fixtures/assets_new_style.qti.xml
+++ b/spec/fixtures/assets_new_style.qti.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment ident="geee6bbefe689398193e27701c896d7b6" title="Quiz with image">
+    <qtimetadata>
+      <qtimetadatafield>
+        <fieldlabel>cc_maxattempts</fieldlabel>
+        <fieldentry>1</fieldentry>
+      </qtimetadatafield>
+    </qtimetadata>
+    <section ident="root_section">
+      <item ident="g43b76ab71793b36116ffb6e7fbad9b6d" title="Question">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_choice_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>points_possible</fieldlabel>
+              <fieldentry>1.0</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>original_answer_ids</fieldlabel>
+              <fieldentry>8889,1600,6475,1164</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>assessment_question_identifierref</fieldlabel>
+              <fieldentry>g6d35a948686cc237529cbe501ca1bf50</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material>
+            <mattext texttype="text/html">
+                &lt;div&gt;&lt;p&gt;&lt;img src="$IMS-CC-FILEBASE$/Uploaded%20Media/apple-1.jpeg" alt="apple-1.jpeg"&gt;&lt;/p&gt;&lt;/div&gt;
+                &lt;div&gt;&lt;p&gt;&lt;img src="$IMS-CC-FILEBASE$/Uploaded%20Media/apple-2.jpeg" alt="apple-2.jpeg"&gt;&lt;/p&gt;&lt;/div&gt;
+            </mattext>
+          </material>
+          <response_lid ident="response1" rcardinality="Single">
+            <render_choice>
+              <response_label ident="8889">
+                <material>
+                  <mattext texttype="text/plain">Correct</mattext>
+                </material>
+              </response_label>
+              <response_label ident="1600">
+                <material>
+                  <mattext texttype="text/plain">Wrong</mattext>
+                </material>
+              </response_label>
+              <response_label ident="6475">
+                <material>
+                  <mattext texttype="text/plain"></mattext>
+                </material>
+              </response_label>
+              <response_label ident="1164">
+                <material>
+                  <mattext texttype="text/plain"></mattext>
+                </material>
+              </response_label>
+            </render_choice>
+          </response_lid>
+        </presentation>
+        <resprocessing>
+          <outcomes>
+            <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/>
+          </outcomes>
+          <respcondition continue="No">
+            <conditionvar>
+              <varequal respident="response1">8889</varequal>
+            </conditionvar>
+            <setvar action="Set" varname="SCORE">100</setvar>
+          </respcondition>
+        </resprocessing>
+      </item>
+    </section>
+  </assessment>
+</questestinterop>

--- a/spec/fixtures/calculated.qti.xml
+++ b/spec/fixtures/calculated.qti.xml
@@ -7,7 +7,7 @@
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>points_possible</fieldlabel>
-        <fieldentry>1.0</fieldentry>
+        <fieldentry>3.0</fieldentry>
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>assessment_question_identifierref</fieldlabel>

--- a/spec/fixtures/essay.qti.xml
+++ b/spec/fixtures/essay.qti.xml
@@ -7,7 +7,7 @@
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>points_possible</fieldlabel>
-        <fieldentry>1.0</fieldentry>
+        <fieldentry>3.0</fieldentry>
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>assessment_question_identifierref</fieldlabel>

--- a/spec/fixtures/file_upload.qti.xml
+++ b/spec/fixtures/file_upload.qti.xml
@@ -7,7 +7,7 @@
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>points_possible</fieldlabel>
-        <fieldentry>1.0</fieldentry>
+        <fieldentry>4.0</fieldentry>
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>assessment_question_identifierref</fieldlabel>

--- a/spec/fixtures/fill_blanks.qti.xml
+++ b/spec/fixtures/fill_blanks.qti.xml
@@ -7,7 +7,7 @@
             </qtimetadatafield>
             <qtimetadatafield>
               <fieldlabel>points_possible</fieldlabel>
-              <fieldentry>1.0</fieldentry>
+              <fieldentry>2.0</fieldentry>
             </qtimetadatafield>
             <qtimetadatafield>
               <fieldlabel>assessment_question_identifierref</fieldlabel>

--- a/spec/fixtures/matching.qti.xml
+++ b/spec/fixtures/matching.qti.xml
@@ -7,7 +7,7 @@
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>points_possible</fieldlabel>
-        <fieldentry>1.0</fieldentry>
+        <fieldentry>3.0</fieldentry>
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>assessment_question_identifierref</fieldlabel>

--- a/spec/fixtures/multiple_answer.qti.xml
+++ b/spec/fixtures/multiple_answer.qti.xml
@@ -7,7 +7,7 @@
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>points_possible</fieldlabel>
-        <fieldentry>1.0</fieldentry>
+        <fieldentry>3.0</fieldentry>
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>assessment_question_identifierref</fieldlabel>

--- a/spec/fixtures/multiple_choice.qti.xml
+++ b/spec/fixtures/multiple_choice.qti.xml
@@ -7,7 +7,7 @@
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>points_possible</fieldlabel>
-        <fieldentry>1.0</fieldentry>
+        <fieldentry>3.0</fieldentry>
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>assessment_question_identifierref</fieldlabel>

--- a/spec/fixtures/multiple_dropdowns.qti.xml
+++ b/spec/fixtures/multiple_dropdowns.qti.xml
@@ -7,7 +7,7 @@
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>points_possible</fieldlabel>
-        <fieldentry>1.0</fieldentry>
+        <fieldentry>3.0</fieldentry>
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>assessment_question_identifierref</fieldlabel>

--- a/spec/fixtures/number.qti.xml
+++ b/spec/fixtures/number.qti.xml
@@ -7,7 +7,7 @@
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>points_possible</fieldlabel>
-        <fieldentry>1.0</fieldentry>
+        <fieldentry>2.0</fieldentry>
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>assessment_question_identifierref</fieldlabel>

--- a/spec/fixtures/numerical.qti.xml
+++ b/spec/fixtures/numerical.qti.xml
@@ -7,7 +7,7 @@
             </qtimetadatafield>
             <qtimetadatafield>
               <fieldlabel>points_possible</fieldlabel>
-              <fieldentry>1.0</fieldentry>
+              <fieldentry>2.0</fieldentry>
             </qtimetadatafield>
             <qtimetadatafield>
               <fieldlabel>assessment_question_identifierref</fieldlabel>

--- a/spec/fixtures/short_answer.qti.xml
+++ b/spec/fixtures/short_answer.qti.xml
@@ -7,7 +7,7 @@
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>points_possible</fieldlabel>
-        <fieldentry>1.0</fieldentry>
+        <fieldentry>2.0</fieldentry>
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>assessment_question_identifierref</fieldlabel>

--- a/spec/fixtures/true_false.qti.xml
+++ b/spec/fixtures/true_false.qti.xml
@@ -7,7 +7,7 @@
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>points_possible</fieldlabel>
-        <fieldentry>1.0</fieldentry>
+        <fieldentry>3.0</fieldentry>
       </qtimetadatafield>
       <qtimetadatafield>
         <fieldlabel>assessment_question_identifierref</fieldlabel>


### PR DESCRIPTION
Fixes and improvements

- Fix asset import 
- Preserve question title and points possible on import
- Fix multiple choice multiple answer imports
- Switch to "partialMatchV2" scoring with no rounding for multiple part
  questions. This more closely matches Canvas scoring behavior
- Matching questions now convert to multiple dropdown questions to more
   closely match Canvas behavior
