### PR TITLE
Fix asset path decoding

### DIFF
--- a/lib/canvas_qti_to_learnosity_converter/convert.rb
+++ b/lib/canvas_qti_to_learnosity_converter/convert.rb
@@ -84,7 +84,7 @@ module CanvasQtiToLearnosityConverter
 
   def self.add_files_to_assets(assets, path, text)
     text.scan(/(%24|\$)IMS-CC-FILEBASE\1\/([^"]+)/) do |_delimiter, asset_path|
-      decoded_path = CGI.unescape(asset_path)
+      decoded_path = URI::DEFAULT_PARSER.unescape(asset_path)
       assets[decoded_path] ||= []
       assets[decoded_path].push(path)
     end

--- a/lib/canvas_qti_to_learnosity_converter/version.rb
+++ b/lib/canvas_qti_to_learnosity_converter/version.rb
@@ -1,3 +1,3 @@
 module CanvasQtiToLearnosityConverter
-  VERSION = "2.4.0"
+  VERSION = "2.4.1"
 end


### PR DESCRIPTION
This fixes quiz imports with a '+' character in the asset path.