### PR TITLE
Js/feedback fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    canvas_qti_to_learnosity_converter (3.3.0)
+    canvas_qti_to_learnosity_converter (3.4.0)
       activesupport
       nokogiri
       rubyzip (~> 3.0)

--- a/docs/superpowers/plans/2026-03-17-feedback-support.md
+++ b/docs/superpowers/plans/2026-03-17-feedback-support.md
@@ -1,0 +1,386 @@
+# Feedback Support Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `itemfeedback` elements from Canvas QTI and populate Learnosity `metadata` fields (correct_feedback, general_feedback, incorrect_feedback, distractor_rationale_response_level).
+
+**Architecture:** Add `extract_feedback` to the `QuizQuestion` base class, then update `convert` in the same class to merge the result into `metadata`. No individual question type files require changes — all feedback idents are at the item level and follow the same extraction pattern regardless of question type.
+
+**Tech Stack:** Ruby, Nokogiri, RSpec
+
+---
+
+## Chunk 1: All Changes
+
+### Task 1: Add `extract_feedback` and tests
+
+**Files:**
+- Modify: `lib/canvas_qti_to_learnosity_converter/questions/question.rb`
+- Test: `spec/canvas_qti_to_learnosity_converter_spec.rb`
+
+The QTI structure for all feedback:
+```xml
+<item>
+  <itemfeedback ident="abc123_fb">         <!-- per-answer distractor rationale -->
+    <flow_mat><material><mattext texttype="text/html">&lt;p&gt;Answer A feedback&lt;/p&gt;</mattext></material></flow_mat>
+  </itemfeedback>
+  <itemfeedback ident="correct_fb">
+    <flow_mat><material><mattext texttype="text/html">&lt;p&gt;Correct!&lt;/p&gt;</mattext></material></flow_mat>
+  </itemfeedback>
+  <itemfeedback ident="general_fb">
+    <flow_mat><material><mattext texttype="text/html">&lt;p&gt;General feedback&lt;/p&gt;</mattext></material></flow_mat>
+  </itemfeedback>
+  <itemfeedback ident="general_incorrect_fb">
+    <flow_mat><material><mattext texttype="text/html">&lt;p&gt;Incorrect!&lt;/p&gt;</mattext></material></flow_mat>
+  </itemfeedback>
+</item>
+```
+
+- [ ] **Step 1: Write the failing tests for `extract_feedback`**
+
+Add a new `describe "feedback"` block to `spec/canvas_qti_to_learnosity_converter_spec.rb` before the final `end` at line 1063. The insertion point looks like:
+
+```ruby
+  # ...existing tests...
+  end
+end  # <-- insert describe "feedback" do ... end before this line
+```
+
+Full block to insert:
+
+```ruby
+describe "feedback" do
+  let(:qti_with_all_feedback) do
+    <<~XML
+      <item ident="test" title="Q">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield><fieldlabel>question_type</fieldlabel><fieldentry>multiple_choice_question</fieldentry></qtimetadatafield>
+            <qtimetadatafield><fieldlabel>points_possible</fieldlabel><fieldentry>1.0</fieldentry></qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material><mattext texttype="text/html">Q?</mattext></material>
+          <response_lid ident="response1" rcardinality="Single">
+            <render_choice>
+              <response_label ident="abc123"><material><mattext texttype="text/plain">A</mattext></material></response_label>
+              <response_label ident="def456"><material><mattext texttype="text/plain">B</mattext></material></response_label>
+            </render_choice>
+          </response_lid>
+        </presentation>
+        <resprocessing>
+          <outcomes><decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/></outcomes>
+          <respcondition continue="No"><conditionvar><varequal respident="response1">abc123</varequal></conditionvar><setvar action="Set" varname="SCORE">100</setvar></respcondition>
+        </resprocessing>
+        <itemfeedback ident="abc123_fb">
+          <flow_mat><material><mattext texttype="text/html">&lt;p&gt;Answer A feedback&lt;/p&gt;</mattext></material></flow_mat>
+        </itemfeedback>
+        <itemfeedback ident="def456_fb">
+          <flow_mat><material><mattext texttype="text/html">&lt;p&gt;Answer B feedback&lt;/p&gt;</mattext></material></flow_mat>
+        </itemfeedback>
+        <itemfeedback ident="correct_fb">
+          <flow_mat><material><mattext texttype="text/html">&lt;p&gt;Correct!&lt;/p&gt;</mattext></material></flow_mat>
+        </itemfeedback>
+        <itemfeedback ident="general_fb">
+          <flow_mat><material><mattext texttype="text/html">&lt;p&gt;General feedback&lt;/p&gt;</mattext></material></flow_mat>
+        </itemfeedback>
+        <itemfeedback ident="general_incorrect_fb">
+          <flow_mat><material><mattext texttype="text/html">&lt;p&gt;Incorrect!&lt;/p&gt;</mattext></material></flow_mat>
+        </itemfeedback>
+      </item>
+    XML
+  end
+
+  let(:qti_with_general_only) do
+    <<~XML
+      <item ident="test" title="Q">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield><fieldlabel>question_type</fieldlabel><fieldentry>essay_question</fieldentry></qtimetadatafield>
+            <qtimetadatafield><fieldlabel>points_possible</fieldlabel><fieldentry>1.0</fieldentry></qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material><mattext texttype="text/html">Write something.</mattext></material>
+          <response_str ident="response1" rcardinality="Single"><render_fib/></response_str>
+        </presentation>
+        <resprocessing>
+          <outcomes><decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/></outcomes>
+        </resprocessing>
+        <itemfeedback ident="general_fb">
+          <flow_mat><material><mattext texttype="text/html">&lt;p&gt;General only&lt;/p&gt;</mattext></material></flow_mat>
+        </itemfeedback>
+      </item>
+    XML
+  end
+
+  let(:qti_with_no_feedback) do
+    <<~XML
+      <item ident="test" title="Q">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield><fieldlabel>question_type</fieldlabel><fieldentry>essay_question</fieldentry></qtimetadatafield>
+            <qtimetadatafield><fieldlabel>points_possible</fieldlabel><fieldentry>1.0</fieldentry></qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material><mattext texttype="text/html">Write something.</mattext></material>
+          <response_str ident="response1" rcardinality="Single"><render_fib/></response_str>
+        </presentation>
+        <resprocessing>
+          <outcomes><decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/></outcomes>
+        </resprocessing>
+      </item>
+    XML
+  end
+
+  it "extracts all feedback types" do
+    _, question = subject.convert_item(qti_string: qti_with_all_feedback)
+    feedback = question.extract_feedback
+
+    expect(feedback).to eq({
+      correct_feedback: "<p>Correct!</p>",
+      general_feedback: "<p>General feedback</p>",
+      incorrect_feedback: "<p>Incorrect!</p>",
+      distractor_rationale_response_level: ["<p>Answer A feedback</p>", "<p>Answer B feedback</p>"],
+    })
+  end
+
+  it "extracts only the feedback that is present" do
+    _, question = subject.convert_item(qti_string: qti_with_general_only)
+    feedback = question.extract_feedback
+
+    expect(feedback).to eq({ general_feedback: "<p>General only</p>" })
+  end
+
+  it "returns an empty hash when no feedback is present" do
+    _, question = subject.convert_item(qti_string: qti_with_no_feedback)
+    expect(question.extract_feedback).to eq({})
+  end
+
+  it "collects per-answer feedbacks in document order" do
+    qti = <<~XML
+      <item ident="test" title="Q">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield><fieldlabel>question_type</fieldlabel><fieldentry>multiple_choice_question</fieldentry></qtimetadatafield>
+            <qtimetadatafield><fieldlabel>points_possible</fieldlabel><fieldentry>1.0</fieldentry></qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material><mattext texttype="text/html">Q?</mattext></material>
+          <response_lid ident="response1" rcardinality="Single">
+            <render_choice>
+              <response_label ident="first"><material><mattext>A</mattext></material></response_label>
+              <response_label ident="second"><material><mattext>B</mattext></material></response_label>
+              <response_label ident="third"><material><mattext>C</mattext></material></response_label>
+            </render_choice>
+          </response_lid>
+        </presentation>
+        <resprocessing>
+          <outcomes><decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/></outcomes>
+          <respcondition continue="No"><conditionvar><varequal respident="response1">first</varequal></conditionvar><setvar action="Set" varname="SCORE">100</setvar></respcondition>
+        </resprocessing>
+        <itemfeedback ident="first_fb">
+          <flow_mat><material><mattext texttype="text/html">First</mattext></material></flow_mat>
+        </itemfeedback>
+        <itemfeedback ident="second_fb">
+          <flow_mat><material><mattext texttype="text/html">Second</mattext></material></flow_mat>
+        </itemfeedback>
+        <itemfeedback ident="third_fb">
+          <flow_mat><material><mattext texttype="text/html">Third</mattext></material></flow_mat>
+        </itemfeedback>
+      </item>
+    XML
+    _, question = subject.convert_item(qti_string: qti)
+    feedback = question.extract_feedback
+
+    expect(feedback[:distractor_rationale_response_level]).to eq(["First", "Second", "Third"])
+  end
+
+  it "skips per-answer feedbacks with empty content" do
+    qti = <<~XML
+      <item ident="test" title="Q">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield><fieldlabel>question_type</fieldlabel><fieldentry>multiple_choice_question</fieldentry></qtimetadatafield>
+            <qtimetadatafield><fieldlabel>points_possible</fieldlabel><fieldentry>1.0</fieldentry></qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material><mattext texttype="text/html">Q?</mattext></material>
+          <response_lid ident="response1" rcardinality="Single">
+            <render_choice>
+              <response_label ident="opt1"><material><mattext>A</mattext></material></response_label>
+            </render_choice>
+          </response_lid>
+        </presentation>
+        <resprocessing>
+          <outcomes><decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/></outcomes>
+          <respcondition continue="No"><conditionvar><varequal respident="response1">opt1</varequal></conditionvar><setvar action="Set" varname="SCORE">100</setvar></respcondition>
+        </resprocessing>
+        <itemfeedback ident="opt1_fb">
+          <flow_mat><material><mattext texttype="text/html"></mattext></material></flow_mat>
+        </itemfeedback>
+        <itemfeedback ident="general_fb">
+          <flow_mat><material><mattext texttype="text/html"></mattext></material></flow_mat>
+        </itemfeedback>
+      </item>
+    XML
+    _, question = subject.convert_item(qti_string: qti)
+    expect(question.extract_feedback).to eq({})
+  end
+end
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+bundle exec rspec spec/canvas_qti_to_learnosity_converter_spec.rb -e "feedback" --format documentation
+```
+
+Expected: 3 failures with `NoMethodError: undefined method 'extract_feedback'`
+
+- [ ] **Step 3: Implement `extract_feedback` in the base class**
+
+Add the following method to `lib/canvas_qti_to_learnosity_converter/questions/question.rb`, between the `extract_points_possible` method and the `extract_mattext` method:
+
+```ruby
+def extract_feedback
+  feedback = {}
+  distractor_rationale = []
+
+  @xml.css("item > itemfeedback").each do |node|
+    ident = node.attribute("ident")&.value
+    text = node.css("flow_mat > material > mattext").first&.content
+    next if text.nil? || text.empty?
+
+    case ident
+    when "correct_fb"           then feedback[:correct_feedback] = text
+    when "general_fb"           then feedback[:general_feedback] = text
+    when "general_incorrect_fb" then feedback[:incorrect_feedback] = text
+    else distractor_rationale << text if ident&.end_with?("_fb")
+    end
+  end
+
+  feedback[:distractor_rationale_response_level] = distractor_rationale unless distractor_rationale.empty?
+  feedback
+end
+```
+
+- [ ] **Step 4: Run the feedback tests to verify they pass**
+
+```bash
+bundle exec rspec spec/canvas_qti_to_learnosity_converter_spec.rb -e "feedback" --format documentation
+```
+
+Expected: 5 examples, 0 failures
+
+- [ ] **Step 5: Run the full test suite to make sure nothing is broken**
+
+```bash
+bundle exec rspec
+```
+
+Expected: all existing tests still pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/canvas_qti_to_learnosity_converter/questions/question.rb spec/canvas_qti_to_learnosity_converter_spec.rb
+git commit -m "feat: add extract_feedback to QuizQuestion base class"
+```
+
+---
+
+### Task 2: Wire feedback into `convert` and add integration test
+
+**Files:**
+- Modify: `lib/canvas_qti_to_learnosity_converter/questions/question.rb`
+- Test: `spec/canvas_qti_to_learnosity_converter_spec.rb`
+
+- [ ] **Step 1: Write a failing integration test**
+
+Add one more test inside the `describe "feedback"` block, after the existing three:
+
+```ruby
+it "includes feedback in the convert output" do
+  _, question = subject.convert_item(qti_string: qti_with_all_feedback)
+  result = question.convert({}, "")
+
+  expect(result[:metadata]).to eq({
+    correct_feedback: "<p>Correct!</p>",
+    general_feedback: "<p>General feedback</p>",
+    incorrect_feedback: "<p>Incorrect!</p>",
+    distractor_rationale_response_level: ["<p>Answer A feedback</p>", "<p>Answer B feedback</p>"],
+  })
+end
+
+it "does not add a metadata key when there is no feedback" do
+  _, question = subject.convert_item(qti_string: qti_with_no_feedback)
+  result = question.convert({}, "")
+
+  expect(result).not_to have_key(:metadata)
+end
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+```bash
+bundle exec rspec spec/canvas_qti_to_learnosity_converter_spec.rb -e "feedback" --format documentation
+```
+
+Expected: 2 new failures — `convert` does not yet merge feedback into the output
+
+- [ ] **Step 3: Update `convert` in the base class**
+
+Replace the existing `convert` method in `lib/canvas_qti_to_learnosity_converter/questions/question.rb` (currently lines 88–91):
+
+```ruby
+# Before:
+def convert(assets, path)
+  object = to_learnosity
+  add_learnosity_assets(assets, path, object)
+end
+```
+
+With:
+
+```ruby
+# After:
+def convert(assets, path)
+  object = to_learnosity
+  add_learnosity_assets(assets, path, object)
+
+  feedback = extract_feedback
+  unless feedback.empty?
+    object[:metadata] ||= {}
+    object[:metadata].merge!(feedback)
+  end
+
+  object
+end
+```
+
+- [ ] **Step 4: Run the feedback tests to verify all 7 pass**
+
+```bash
+bundle exec rspec spec/canvas_qti_to_learnosity_converter_spec.rb -e "feedback" --format documentation
+```
+
+Expected: 7 examples, 0 failures
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+bundle exec rspec
+```
+
+Expected: all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/canvas_qti_to_learnosity_converter/questions/question.rb spec/canvas_qti_to_learnosity_converter_spec.rb
+git commit -m "feat: include feedback metadata in convert output"
+```

--- a/docs/superpowers/specs/2026-03-17-feedback-support-design.md
+++ b/docs/superpowers/specs/2026-03-17-feedback-support-design.md
@@ -1,0 +1,117 @@
+# Feedback Support Design
+
+**Date:** 2026-03-17
+**Status:** Approved
+
+## Problem
+
+Canvas QTI exports include `itemfeedback` elements for correct, incorrect, general, and per-answer feedback. The converter currently ignores all of these, so feedback is lost when importing into Learnosity.
+
+## QTI Feedback Structure
+
+All feedback lives as `itemfeedback` siblings to `presentation` and `resprocessing` inside `item`. The ident attribute determines the type:
+
+| QTI ident | Type |
+|---|---|
+| `correct_fb` | Shown when the student answers correctly |
+| `general_fb` | Always shown after submission |
+| `general_incorrect_fb` | Shown when the student answers incorrectly |
+| `{anything}_fb` | Per-answer distractor rationale |
+
+The per-answer idents vary by question type (UUIDs for MCQ, numeric IDs for Matching, answer IDs for Numerical) but the extraction logic is identical: collect all `itemfeedback` elements whose ident ends in `_fb` and does not match the three special idents.
+
+## Learnosity Mapping
+
+All feedback maps to the `metadata` field of the Learnosity question object:
+
+| QTI ident | Learnosity field |
+|---|---|
+| `correct_fb` | `metadata.correct_feedback` |
+| `general_fb` | `metadata.general_feedback` |
+| `general_incorrect_fb` | `metadata.incorrect_feedback` |
+| `{anything}_fb` (multiple) | `metadata.distractor_rationale_response_level` (array, document order) |
+
+Canvas exports per-answer `itemfeedback` elements in option order, so document order produces a correctly-aligned array without needing to cross-reference the `presentation` section.
+
+The `metadata` key is only added to the question object when at least one feedback field is present.
+
+## Data Flow
+
+Current:
+```
+to_learnosity → add_learnosity_assets → return object
+```
+
+Proposed:
+```
+to_learnosity → add_learnosity_assets → extract_feedback → merge metadata → return object
+```
+
+No changes to `to_learnosity` in any question class. Feedback extraction is appended to the existing pipeline in the base class `convert` method.
+
+## Implementation
+
+### `extract_feedback` (new method on `QuizQuestion`)
+
+```ruby
+def extract_feedback
+  feedback = {}
+  distractor_rationale = []
+
+  @xml.css("item > itemfeedback").each do |node|
+    ident = node.attribute("ident")&.value
+    text = node.css("flow_mat > material > mattext").first&.content
+    next if text.nil? || text.empty?
+
+    case ident
+    when "correct_fb"           then feedback[:correct_feedback] = text
+    when "general_fb"           then feedback[:general_feedback] = text
+    when "general_incorrect_fb" then feedback[:incorrect_feedback] = text
+    else distractor_rationale << text if ident&.end_with?("_fb")
+    end
+  end
+
+  feedback[:distractor_rationale_response_level] = distractor_rationale unless distractor_rationale.empty?
+  feedback
+end
+```
+
+### Updated `convert` (modified on `QuizQuestion`)
+
+```ruby
+def convert(assets, path)
+  object = to_learnosity
+  add_learnosity_assets(assets, path, object)
+
+  feedback = extract_feedback
+  unless feedback.empty?
+    object[:metadata] ||= {}
+    object[:metadata].merge!(feedback)
+  end
+
+  object
+end
+```
+
+### HTML Content
+
+`.content` on the `mattext` Nokogiri node decodes XML entities and returns the HTML string (e.g. `<p>Feedback for Correct</p>`), consistent with how `extract_mattext` works for stimulus and option labels.
+
+## Files Changed
+
+- `lib/canvas_qti_to_learnosity_converter/questions/question.rb` — add `extract_feedback`, update `convert`
+
+## Files Unchanged
+
+All individual question type files (`multiple_choice.rb`, `matching.rb`, `numerical.rb`, etc.) require no changes.
+
+## Testing
+
+New tests added to the existing spec file using inline QTI strings:
+
+1. **All four feedback types present** — verifies correct/general/incorrect feedback and distractor_rationale_response_level array
+2. **Only general feedback** — verifies partial feedback sets work and no empty fields are included
+3. **No feedback** — verifies no `metadata` key is added to the output
+4. **Multiple per-answer feedbacks** — verifies distractor_rationale_response_level array is ordered correctly
+
+Existing tests are unaffected since `extract_feedback` returns an empty hash when no `itemfeedback` elements exist.

--- a/docs/superpowers/specs/2026-03-17-feedback-support-design.md
+++ b/docs/superpowers/specs/2026-03-17-feedback-support-design.md
@@ -18,7 +18,11 @@ All feedback lives as `itemfeedback` siblings to `presentation` and `resprocessi
 | `general_incorrect_fb` | Shown when the student answers incorrectly |
 | `{anything}_fb` | Per-answer distractor rationale |
 
-The per-answer idents vary by question type (UUIDs for MCQ, numeric IDs for Matching, answer IDs for Numerical) but the extraction logic is identical: collect all `itemfeedback` elements whose ident ends in `_fb` and does not match the three special idents.
+The per-answer idents vary by question type (UUIDs for MCQ, numeric IDs for Matching/Numerical) but the extraction logic is identical: collect all `itemfeedback` elements whose ident ends in `_fb` and does not match the three special idents. Canvas exports them in option order, so document order produces a correctly-aligned array.
+
+### Fill-in-Multiple-Blanks Edge Case
+
+Fill-in-multiple-blanks questions in Canvas Classic can export per-blank feedback idents in QTI (e.g. `6491_fb`, `2293_fb`). In practice these elements are always empty in observed exports, and the code skips empty feedback via a nil/empty guard. If non-empty per-blank feedbacks do appear, they will be collected into `distractor_rationale_response_level` in document order, which may not perfectly align with Learnosity's expected structure for `clozetext` questions (which has multiple blanks). This is acceptable as a best-effort and can be revisited if real data surfaces the issue.
 
 ## Learnosity Mapping
 
@@ -31,27 +35,31 @@ All feedback maps to the `metadata` field of the Learnosity question object:
 | `general_incorrect_fb` | `metadata.incorrect_feedback` |
 | `{anything}_fb` (multiple) | `metadata.distractor_rationale_response_level` (array, document order) |
 
-Canvas exports per-answer `itemfeedback` elements in option order, so document order produces a correctly-aligned array without needing to cross-reference the `presentation` section.
+The `metadata` key is only added to the question object when at least one feedback field is non-empty. No current question class returns `:metadata` from `to_learnosity`; the `||=` in `convert` is forward-compatible defensive coding for future subclasses. Note that `object` here is the inner question data hash returned by `to_learnosity`, not the outer widget wrapper hash (which has its own `:metadata` key in `convert.rb`). There is no conflict between these two levels.
 
-The `metadata` key is only added to the question object when at least one feedback field is present.
+`TextOnlyQuestion` (sharedpassage/feature type) goes through the same `convert` path. Since text-only items do not contain `itemfeedback` elements, `extract_feedback` returns `{}` and no metadata is added. No special handling is needed.
 
 ## Data Flow
 
 Current:
 ```
-to_learnosity → add_learnosity_assets → return object
+to_learnosity → add_learnosity_assets → return (implicit return of add_learnosity_assets result)
 ```
 
 Proposed:
 ```
-to_learnosity → add_learnosity_assets → extract_feedback → merge metadata → return object
+to_learnosity → add_learnosity_assets → extract_feedback → merge metadata → return object (explicit)
 ```
 
-No changes to `to_learnosity` in any question class. Feedback extraction is appended to the existing pipeline in the base class `convert` method.
+All `add_learnosity_assets` implementations return their `learnosity` argument, so the current implicit return is equivalent to an explicit return of `object`. The proposed code makes this explicit, which is a minor improvement in clarity.
+
+No changes to `to_learnosity` in any question class. Feedback extraction is appended to the existing pipeline in the base class `convert` method only.
 
 ## Implementation
 
 ### `extract_feedback` (new method on `QuizQuestion`)
+
+`@xml` is a Nokogiri document wrapping the `item` element (consistent with how `extract_stimulus` uses `@xml.css("item > presentation > material > mattext")`). The `item > itemfeedback` direct-child selector is therefore correct.
 
 ```ruby
 def extract_feedback
@@ -95,7 +103,7 @@ end
 
 ### HTML Content
 
-`.content` on the `mattext` Nokogiri node decodes XML entities and returns the HTML string (e.g. `<p>Feedback for Correct</p>`), consistent with how `extract_mattext` works for stimulus and option labels.
+The `mattext` node in QTI stores rich text as entity-escaped HTML (e.g. `&lt;p&gt;Feedback&lt;/p&gt;`). Nokogiri's `.content` decodes XML entities, returning the HTML markup string `<p>Feedback</p>`. This is the same behavior as `extract_mattext` used for stimulus and option labels throughout the codebase. Learnosity `metadata` feedback fields accept HTML strings.
 
 ## Files Changed
 
@@ -107,11 +115,11 @@ All individual question type files (`multiple_choice.rb`, `matching.rb`, `numeri
 
 ## Testing
 
-New tests added to the existing spec file using inline QTI strings:
+New tests added inline (using QTI strings rather than fixture files, to isolate feedback behavior from unrelated question-conversion logic):
 
-1. **All four feedback types present** — verifies correct/general/incorrect feedback and distractor_rationale_response_level array
-2. **Only general feedback** — verifies partial feedback sets work and no empty fields are included
-3. **No feedback** — verifies no `metadata` key is added to the output
-4. **Multiple per-answer feedbacks** — verifies distractor_rationale_response_level array is ordered correctly
+1. **All four feedback types present** — MCQ with correct/general/incorrect feedback and one per-answer feedback. Use a UUID-style ident ending in `_fb` (e.g. `abc123_fb`) for the per-answer element to match the MCQ ident pattern observed in Canvas exports. Asserts `result[:metadata]` equals expected hash including `distractor_rationale_response_level`.
+2. **Only general feedback** — Asserts only `general_feedback` key is present; no empty fields included.
+3. **No feedback** — Asserts `expect(result).not_to have_key(:metadata)`.
+4. **Multiple per-answer feedbacks** — Two options with feedback, verifies array length and order.
 
-Existing tests are unaffected since `extract_feedback` returns an empty hash when no `itemfeedback` elements exist.
+Existing tests are unaffected since `extract_feedback` returns `{}` when no `itemfeedback` elements exist, leaving the output object unchanged.

--- a/lib/canvas_qti_to_learnosity_converter/questions/question.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/question.rb
@@ -112,6 +112,16 @@ module CanvasQtiToLearnosityConverter
       add_learnosity_assets(assets, path, object) # mutates object in place; return value unused
       feedback = extract_feedback
       unless feedback.empty?
+        # Ensure any asset references in feedback HTML are processed and collected.
+        feedback.each do |key, value|
+          if value.is_a?(String)
+            process_assets!(assets, path, value)
+          elsif key.to_s == "distractor_rationale_response_level" && value.is_a?(Array)
+            value.each do |entry|
+              process_assets!(assets, path, entry) if entry.is_a?(String)
+            end
+          end
+        end
         object[:metadata] ||= {}
         object[:metadata].merge!(feedback)
       end

--- a/lib/canvas_qti_to_learnosity_converter/questions/question.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/question.rb
@@ -109,7 +109,7 @@ module CanvasQtiToLearnosityConverter
 
     def convert(assets, path)
       object = to_learnosity
-      add_learnosity_assets(assets, path, object)
+      add_learnosity_assets(assets, path, object) # mutates object in place; return value unused
 
       feedback = extract_feedback
       unless feedback.empty?

--- a/lib/canvas_qti_to_learnosity_converter/questions/question.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/question.rb
@@ -24,6 +24,27 @@ module CanvasQtiToLearnosityConverter
         &.first&.next&.text&.to_f || 1.0
     end
 
+    def extract_feedback
+      feedback = {}
+      distractor_rationale = []
+
+      @xml.css("item > itemfeedback").each do |node|
+        ident = node.attribute("ident")&.value
+        text = node.css("flow_mat > material > mattext").first&.content
+        next if text.nil? || text.empty?
+
+        case ident
+        when "correct_fb"           then feedback[:correct_feedback] = text
+        when "general_fb"           then feedback[:general_feedback] = text
+        when "general_incorrect_fb" then feedback[:incorrect_feedback] = text
+        else distractor_rationale << text if ident&.end_with?("_fb")
+        end
+      end
+
+      feedback[:distractor_rationale_response_level] = distractor_rationale unless distractor_rationale.empty?
+      feedback
+    end
+
     def extract_mattext(mattext_node)
       mattext_node.content
     end

--- a/lib/canvas_qti_to_learnosity_converter/questions/question.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/question.rb
@@ -110,6 +110,14 @@ module CanvasQtiToLearnosityConverter
     def convert(assets, path)
       object = to_learnosity
       add_learnosity_assets(assets, path, object)
+
+      feedback = extract_feedback
+      unless feedback.empty?
+        object[:metadata] ||= {}
+        object[:metadata].merge!(feedback)
+      end
+
+      object
     end
   end
 end

--- a/lib/canvas_qti_to_learnosity_converter/questions/question.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/question.rb
@@ -110,7 +110,6 @@ module CanvasQtiToLearnosityConverter
     def convert(assets, path)
       object = to_learnosity
       add_learnosity_assets(assets, path, object) # mutates object in place; return value unused
-
       feedback = extract_feedback
       unless feedback.empty?
         object[:metadata] ||= {}

--- a/lib/canvas_qti_to_learnosity_converter/questions/question.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/question.rb
@@ -37,6 +37,7 @@ module CanvasQtiToLearnosityConverter
         when "correct_fb"           then feedback[:correct_feedback] = text
         when "general_fb"           then feedback[:general_feedback] = text
         when "general_incorrect_fb" then feedback[:incorrect_feedback] = text
+        # Any other *_fb ident (e.g. per-answer labels like "abc123_fb") is treated as per-answer distractor rationale.
         else distractor_rationale << text if ident&.end_with?("_fb")
         end
       end

--- a/lib/canvas_qti_to_learnosity_converter/version.rb
+++ b/lib/canvas_qti_to_learnosity_converter/version.rb
@@ -1,3 +1,3 @@
 module CanvasQtiToLearnosityConverter
-  VERSION = "3.3.0"
+  VERSION = "3.4.0"
 end

--- a/spec/canvas_qti_to_learnosity_converter_spec.rb
+++ b/spec/canvas_qti_to_learnosity_converter_spec.rb
@@ -1305,5 +1305,69 @@ RSpec.describe CanvasQtiToLearnosityConverter do
         general_feedback: "<p>General feedback</p>",
       )
     end
+
+    it "rewrites asset references in string feedback fields and collects them" do
+      qti = <<~XML
+        <item ident="test" title="Q">
+          <itemmetadata>
+            <qtimetadata><qtimetadatafield><fieldlabel>question_type</fieldlabel><fieldentry>multiple_choice_question</fieldentry></qtimetadatafield></qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material><mattext texttype="text/html">Q?</mattext></material>
+            <response_lid ident="response1" rcardinality="Single">
+              <render_choice>
+                <response_label ident="opt1"><material><mattext texttype="text/plain">A</mattext></material></response_label>
+              </render_choice>
+            </response_lid>
+          </presentation>
+          <resprocessing>
+            <outcomes><decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/></outcomes>
+            <respcondition continue="No"><conditionvar><varequal respident="response1">opt1</varequal></conditionvar><setvar action="Set" varname="SCORE">100</setvar></respcondition>
+          </resprocessing>
+          <itemfeedback ident="correct_fb">
+            <flow_mat><material><mattext texttype="text/html">&lt;img src="images/hint.png"/&gt;</mattext></material></flow_mat>
+          </itemfeedback>
+        </item>
+      XML
+      _, question = subject.convert_item(qti_string: qti)
+      assets = {}
+
+      result = question.convert(assets, "")
+
+      expect(assets.keys).to eq(["/images/hint.png"])
+      expect(result.dig(:metadata, :correct_feedback)).to match(%r{___EXPORT_ROOT___/assets/.+\.png})
+    end
+
+    it "rewrites asset references in distractor rationale entries and collects them" do
+      qti = <<~XML
+        <item ident="test" title="Q">
+          <itemmetadata>
+            <qtimetadata><qtimetadatafield><fieldlabel>question_type</fieldlabel><fieldentry>multiple_choice_question</fieldentry></qtimetadatafield></qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material><mattext texttype="text/html">Q?</mattext></material>
+            <response_lid ident="response1" rcardinality="Single">
+              <render_choice>
+                <response_label ident="opt1"><material><mattext texttype="text/plain">A</mattext></material></response_label>
+              </render_choice>
+            </response_lid>
+          </presentation>
+          <resprocessing>
+            <outcomes><decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/></outcomes>
+            <respcondition continue="No"><conditionvar><varequal respident="response1">opt1</varequal></conditionvar><setvar action="Set" varname="SCORE">100</setvar></respcondition>
+          </resprocessing>
+          <itemfeedback ident="opt1_fb">
+            <flow_mat><material><mattext texttype="text/html">&lt;img src="images/distractor.png"/&gt;</mattext></material></flow_mat>
+          </itemfeedback>
+        </item>
+      XML
+      _, question = subject.convert_item(qti_string: qti)
+      assets = {}
+
+      result = question.convert(assets, "")
+
+      expect(assets.keys).to eq(["/images/distractor.png"])
+      expect(result.dig(:metadata, :distractor_rationale_response_level).first).to match(%r{___EXPORT_ROOT___/assets/.+\.png})
+    end
   end
 end

--- a/spec/canvas_qti_to_learnosity_converter_spec.rb
+++ b/spec/canvas_qti_to_learnosity_converter_spec.rb
@@ -1060,4 +1060,187 @@ RSpec.describe CanvasQtiToLearnosityConverter do
       expect(subject.assessments[0][:data][:items].count).to eql(4)
     end
   end
+
+  describe "feedback" do
+    let(:qti_with_all_feedback) do
+      <<~XML
+        <item ident="test" title="Q">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield><fieldlabel>question_type</fieldlabel><fieldentry>multiple_choice_question</fieldentry></qtimetadatafield>
+              <qtimetadatafield><fieldlabel>points_possible</fieldlabel><fieldentry>1.0</fieldentry></qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material><mattext texttype="text/html">Q?</mattext></material>
+            <response_lid ident="response1" rcardinality="Single">
+              <render_choice>
+                <response_label ident="abc123"><material><mattext texttype="text/plain">A</mattext></material></response_label>
+                <response_label ident="def456"><material><mattext texttype="text/plain">B</mattext></material></response_label>
+              </render_choice>
+            </response_lid>
+          </presentation>
+          <resprocessing>
+            <outcomes><decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/></outcomes>
+            <respcondition continue="No"><conditionvar><varequal respident="response1">abc123</varequal></conditionvar><setvar action="Set" varname="SCORE">100</setvar></respcondition>
+          </resprocessing>
+          <itemfeedback ident="abc123_fb">
+            <flow_mat><material><mattext texttype="text/html">&lt;p&gt;Answer A feedback&lt;/p&gt;</mattext></material></flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="def456_fb">
+            <flow_mat><material><mattext texttype="text/html">&lt;p&gt;Answer B feedback&lt;/p&gt;</mattext></material></flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="correct_fb">
+            <flow_mat><material><mattext texttype="text/html">&lt;p&gt;Correct!&lt;/p&gt;</mattext></material></flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="general_fb">
+            <flow_mat><material><mattext texttype="text/html">&lt;p&gt;General feedback&lt;/p&gt;</mattext></material></flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="general_incorrect_fb">
+            <flow_mat><material><mattext texttype="text/html">&lt;p&gt;Incorrect!&lt;/p&gt;</mattext></material></flow_mat>
+          </itemfeedback>
+        </item>
+      XML
+    end
+
+    let(:qti_with_general_only) do
+      <<~XML
+        <item ident="test" title="Q">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield><fieldlabel>question_type</fieldlabel><fieldentry>essay_question</fieldentry></qtimetadatafield>
+              <qtimetadatafield><fieldlabel>points_possible</fieldlabel><fieldentry>1.0</fieldentry></qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material><mattext texttype="text/html">Write something.</mattext></material>
+            <response_str ident="response1" rcardinality="Single"><render_fib/></response_str>
+          </presentation>
+          <resprocessing>
+            <outcomes><decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/></outcomes>
+          </resprocessing>
+          <itemfeedback ident="general_fb">
+            <flow_mat><material><mattext texttype="text/html">&lt;p&gt;General only&lt;/p&gt;</mattext></material></flow_mat>
+          </itemfeedback>
+        </item>
+      XML
+    end
+
+    let(:qti_with_no_feedback) do
+      <<~XML
+        <item ident="test" title="Q">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield><fieldlabel>question_type</fieldlabel><fieldentry>essay_question</fieldentry></qtimetadatafield>
+              <qtimetadatafield><fieldlabel>points_possible</fieldlabel><fieldentry>1.0</fieldentry></qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material><mattext texttype="text/html">Write something.</mattext></material>
+            <response_str ident="response1" rcardinality="Single"><render_fib/></response_str>
+          </presentation>
+          <resprocessing>
+            <outcomes><decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/></outcomes>
+          </resprocessing>
+        </item>
+      XML
+    end
+
+    it "extracts all feedback types" do
+      _, question = subject.convert_item(qti_string: qti_with_all_feedback)
+      feedback = question.extract_feedback
+
+      expect(feedback).to eq({
+        correct_feedback: "<p>Correct!</p>",
+        general_feedback: "<p>General feedback</p>",
+        incorrect_feedback: "<p>Incorrect!</p>",
+        distractor_rationale_response_level: ["<p>Answer A feedback</p>", "<p>Answer B feedback</p>"],
+      })
+    end
+
+    it "extracts only the feedback that is present" do
+      _, question = subject.convert_item(qti_string: qti_with_general_only)
+      feedback = question.extract_feedback
+
+      expect(feedback).to eq({ general_feedback: "<p>General only</p>" })
+    end
+
+    it "returns an empty hash when no feedback is present" do
+      _, question = subject.convert_item(qti_string: qti_with_no_feedback)
+      expect(question.extract_feedback).to eq({})
+    end
+
+    it "collects per-answer feedbacks in document order" do
+      qti = <<~XML
+        <item ident="test" title="Q">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield><fieldlabel>question_type</fieldlabel><fieldentry>multiple_choice_question</fieldentry></qtimetadatafield>
+              <qtimetadatafield><fieldlabel>points_possible</fieldlabel><fieldentry>1.0</fieldentry></qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material><mattext texttype="text/html">Q?</mattext></material>
+            <response_lid ident="response1" rcardinality="Single">
+              <render_choice>
+                <response_label ident="first"><material><mattext>A</mattext></material></response_label>
+                <response_label ident="second"><material><mattext>B</mattext></material></response_label>
+                <response_label ident="third"><material><mattext>C</mattext></material></response_label>
+              </render_choice>
+            </response_lid>
+          </presentation>
+          <resprocessing>
+            <outcomes><decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/></outcomes>
+            <respcondition continue="No"><conditionvar><varequal respident="response1">first</varequal></conditionvar><setvar action="Set" varname="SCORE">100</setvar></respcondition>
+          </resprocessing>
+          <itemfeedback ident="first_fb">
+            <flow_mat><material><mattext texttype="text/html">First</mattext></material></flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="second_fb">
+            <flow_mat><material><mattext texttype="text/html">Second</mattext></material></flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="third_fb">
+            <flow_mat><material><mattext texttype="text/html">Third</mattext></material></flow_mat>
+          </itemfeedback>
+        </item>
+      XML
+      _, question = subject.convert_item(qti_string: qti)
+      feedback = question.extract_feedback
+
+      expect(feedback[:distractor_rationale_response_level]).to eq(["First", "Second", "Third"])
+    end
+
+    it "skips per-answer feedbacks with empty content" do
+      qti = <<~XML
+        <item ident="test" title="Q">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield><fieldlabel>question_type</fieldlabel><fieldentry>multiple_choice_question</fieldentry></qtimetadatafield>
+              <qtimetadatafield><fieldlabel>points_possible</fieldlabel><fieldentry>1.0</fieldentry></qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material><mattext texttype="text/html">Q?</mattext></material>
+            <response_lid ident="response1" rcardinality="Single">
+              <render_choice>
+                <response_label ident="opt1"><material><mattext>A</mattext></material></response_label>
+              </render_choice>
+            </response_lid>
+          </presentation>
+          <resprocessing>
+            <outcomes><decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/></outcomes>
+            <respcondition continue="No"><conditionvar><varequal respident="response1">opt1</varequal></conditionvar><setvar action="Set" varname="SCORE">100</setvar></respcondition>
+          </resprocessing>
+          <itemfeedback ident="opt1_fb">
+            <flow_mat><material><mattext texttype="text/html"></mattext></material></flow_mat>
+          </itemfeedback>
+          <itemfeedback ident="general_fb">
+            <flow_mat><material><mattext texttype="text/html"></mattext></material></flow_mat>
+          </itemfeedback>
+        </item>
+      XML
+      _, question = subject.convert_item(qti_string: qti)
+      expect(question.extract_feedback).to eq({})
+    end
+  end
 end

--- a/spec/canvas_qti_to_learnosity_converter_spec.rb
+++ b/spec/canvas_qti_to_learnosity_converter_spec.rb
@@ -1267,5 +1267,24 @@ RSpec.describe CanvasQtiToLearnosityConverter do
       _, question = subject.convert_item(qti_string: qti)
       expect(question.extract_feedback).to eq({})
     end
+
+    it "includes feedback in the convert output" do
+      _, question = subject.convert_item(qti_string: qti_with_all_feedback)
+      result = question.convert({}, "")
+
+      expect(result[:metadata]).to eq({
+        correct_feedback: "<p>Correct!</p>",
+        general_feedback: "<p>General feedback</p>",
+        incorrect_feedback: "<p>Incorrect!</p>",
+        distractor_rationale_response_level: ["<p>Answer A feedback</p>", "<p>Answer B feedback</p>"],
+      })
+    end
+
+    it "does not add a metadata key when there is no feedback" do
+      _, question = subject.convert_item(qti_string: qti_with_no_feedback)
+      result = question.convert({}, "")
+
+      expect(result).not_to have_key(:metadata)
+    end
   end
 end

--- a/spec/canvas_qti_to_learnosity_converter_spec.rb
+++ b/spec/canvas_qti_to_learnosity_converter_spec.rb
@@ -1242,5 +1242,30 @@ RSpec.describe CanvasQtiToLearnosityConverter do
       _, question = subject.convert_item(qti_string: qti)
       expect(question.extract_feedback).to eq({})
     end
+
+    it "ignores itemfeedback elements with no ident attribute" do
+      qti = <<~XML
+        <item ident="test" title="Q">
+          <itemmetadata>
+            <qtimetadata>
+              <qtimetadatafield><fieldlabel>question_type</fieldlabel><fieldentry>essay_question</fieldentry></qtimetadatafield>
+              <qtimetadatafield><fieldlabel>points_possible</fieldlabel><fieldentry>1.0</fieldentry></qtimetadatafield>
+            </qtimetadata>
+          </itemmetadata>
+          <presentation>
+            <material><mattext texttype="text/html">Q?</mattext></material>
+            <response_str ident="response1" rcardinality="Single"><render_fib/></response_str>
+          </presentation>
+          <resprocessing>
+            <outcomes><decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/></outcomes>
+          </resprocessing>
+          <itemfeedback>
+            <flow_mat><material><mattext texttype="text/html">&lt;p&gt;Orphan feedback&lt;/p&gt;</mattext></material></flow_mat>
+          </itemfeedback>
+        </item>
+      XML
+      _, question = subject.convert_item(qti_string: qti)
+      expect(question.extract_feedback).to eq({})
+    end
   end
 end

--- a/spec/canvas_qti_to_learnosity_converter_spec.rb
+++ b/spec/canvas_qti_to_learnosity_converter_spec.rb
@@ -1286,5 +1286,24 @@ RSpec.describe CanvasQtiToLearnosityConverter do
 
       expect(result).not_to have_key(:metadata)
     end
+
+    it "merges feedback into pre-existing metadata without clobbering it" do
+      _, question = subject.convert_item(qti_string: qti_with_all_feedback)
+      learnosity_object = {
+        type: "mcq",
+        stimulus: "Q?",
+        metadata: { existing_key: "existing_value" }
+      }
+      allow(question).to receive(:to_learnosity).and_return(learnosity_object)
+      allow(question).to receive(:add_learnosity_assets)
+
+      result = question.convert({}, "")
+
+      expect(result[:metadata]).to include(
+        existing_key: "existing_value",
+        correct_feedback: "<p>Correct!</p>",
+        general_feedback: "<p>General feedback</p>",
+      )
+    end
   end
 end


### PR DESCRIPTION
This pull request implements support for extracting feedback from Canvas QTI files and populating the corresponding Learnosity metadata fields during question conversion. The changes introduce a new method to extract all relevant feedback types, update the main conversion pipeline to include this feedback, and add comprehensive tests to verify correct extraction and mapping. No individual question type files require changes; all logic is centralized in the base class.

**Feedback extraction and mapping:**

* Added a new `extract_feedback` method to the `QuizQuestion` base class (`question.rb`) to collect `itemfeedback` elements from Canvas QTI, mapping them to Learnosity metadata fields: `correct_feedback`, `general_feedback`, `incorrect_feedback`, and `distractor_rationale_response_level` (array). The method skips empty feedback and collects per-answer feedback in document order.
* Updated the `convert` method in `QuizQuestion` to merge extracted feedback into the output object's `:metadata` key only if feedback is present, ensuring backward compatibility and no changes for questions without feedback.

**Testing and documentation:**

* Added extensive RSpec tests to `canvas_qti_to_learnosity_converter_spec.rb` to verify feedback extraction for all feedback types, partial feedback, no feedback, per-answer feedback order, and correct integration into the conversion output.
* Documented the design and implementation in `2026-03-17-feedback-support-design.md`, describing the QTI structure, Learnosity mapping, data flow, and edge cases, ensuring clarity for future maintenance and extensibility.
* Provided an implementation plan in `2026-03-17-feedback-support.md`, including step-by-step instructions for development and testing, to facilitate agentic or human-driven development.

**Note:**
I observed what seems to be a limitation in Learnosity's format - In Canvas you can associate response with a specific answer based on the response ID, but in Learnosity format the response specific feedback is based on the index positions of the list. This means that we're able to import it correctly, but we might want to take actions in the future to make sure customers are aware of this difference.