### PR TITLE
Js/formula question fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    canvas_qti_to_learnosity_converter (3.4.0)
+    canvas_qti_to_learnosity_converter (3.4.1)
       activesupport
       nokogiri
       rubyzip (~> 3.0)

--- a/lib/canvas_qti_to_learnosity_converter/questions/calculated.rb
+++ b/lib/canvas_qti_to_learnosity_converter/questions/calculated.rb
@@ -14,11 +14,22 @@ module CanvasQtiToLearnosityConverter
 
     def extract_stimulus()
       template = get_template()
+      uses_backtick = template.match?(/`[^`]+`/)
+
       extract_template_values(template).each.with_index do |var_name, index|
-        template.sub!("[#{var_name}]", "{{var:val#{index}}}")
+        pattern = uses_backtick ? "`#{var_name}`" : "[#{var_name}]"
+        template.sub!(pattern, "{{var:val#{index}}}")
       end
 
       template
+    end
+
+    # New Quizzes exports variables with backtick notation (e.g. `w`),
+    # while Classic Quizzes uses square bracket notation (e.g. [w]).
+    # Detect which format is in use and return plain variable names either way.
+    def extract_template_values(template)
+      backtick_vars = template.scan(/`([^`]+)`/).map(&:first)
+      backtick_vars.any? ? backtick_vars : super
     end
 
     def extract_validation()

--- a/lib/canvas_qti_to_learnosity_converter/version.rb
+++ b/lib/canvas_qti_to_learnosity_converter/version.rb
@@ -1,3 +1,3 @@
 module CanvasQtiToLearnosityConverter
-  VERSION = "3.4.0"
+  VERSION = "3.4.1"
 end

--- a/spec/canvas_qti_to_learnosity_converter_spec.rb
+++ b/spec/canvas_qti_to_learnosity_converter_spec.rb
@@ -675,6 +675,33 @@ RSpec.describe CanvasQtiToLearnosityConverter do
         }
       })
     end
+
+    it "handles a New Quizzes calculated question with backtick variable notation" do
+      qti_file = File.new("spec/fixtures/calculated_new_quizzes.qti.xml")
+      qti = qti_file.read
+      question_type, question = subject.convert_item(qti_string: qti)
+
+      dynamic_data = question.dynamic_content_data()
+
+      expect(dynamic_data[:cols]).to eq(["val0", "answer"])
+      expect(dynamic_data[:rows].keys.count).to eq 3
+      row_key = dynamic_data[:rows].keys.first
+      expect(dynamic_data[:rows][row_key][:values].count).to eq 2
+
+      learnosity = question.to_learnosity
+
+      expect(question_type).to eq "question"
+      expect(learnosity[:type]).to eq "clozeformula"
+      expect(learnosity[:stimulus]).to eq "<p>The weight is {{var:val0}} kg. What is double the weight?</p>"
+      expect(learnosity[:template]).to eq "{{response}}"
+      expect(learnosity[:validation]).to eq({
+        "scoring_type" => "exactMatch",
+        "valid_response" => {
+          "score" => 1.0,
+          "value" => [[{ "method" => "equivValue", "value" => "{{var:answer}}\\pm0" }]]
+        }
+      })
+    end
   end
 
   describe "Ordering" do

--- a/spec/fixtures/calculated_new_quizzes.qti.xml
+++ b/spec/fixtures/calculated_new_quizzes.qti.xml
@@ -1,0 +1,69 @@
+<item ident="itest_new_quizzes_calculated" title="Question">
+  <itemmetadata>
+    <qtimetadata>
+      <qtimetadatafield>
+        <fieldlabel>question_type</fieldlabel>
+        <fieldentry>calculated_question</fieldentry>
+      </qtimetadatafield>
+      <qtimetadatafield>
+        <fieldlabel>points_possible</fieldlabel>
+        <fieldentry>1.0</fieldentry>
+      </qtimetadatafield>
+      <qtimetadatafield>
+        <fieldlabel>assessment_question_identifierref</fieldlabel>
+        <fieldentry>i016f3b96bb0675f2f3ffdfe8452f15d5</fieldentry>
+      </qtimetadatafield>
+    </qtimetadata>
+  </itemmetadata>
+  <presentation>
+    <material>
+      <mattext texttype="text/html">&lt;p&gt;The weight is `w` kg. What is double the weight?&lt;/p&gt;</mattext>
+    </material>
+    <response_str ident="response1" rcardinality="Single">
+      <render_fib fibtype="Decimal">
+        <response_label ident="answer1"/>
+      </render_fib>
+    </response_str>
+  </presentation>
+  <resprocessing>
+    <outcomes>
+      <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/>
+    </outcomes>
+    <respcondition title="correct">
+      <conditionvar><other/></conditionvar>
+      <setvar varname="SCORE" action="Set">100</setvar>
+    </respcondition>
+    <respcondition title="incorrect">
+      <conditionvar><not><other/></not></conditionvar>
+      <setvar varname="SCORE" action="Set">0</setvar>
+    </respcondition>
+  </resprocessing>
+  <itemproc_extension>
+    <calculated>
+      <answer_tolerance margin_type="absolute">0</answer_tolerance>
+      <formulas decimal_places="1" scientific_notation="false">
+        <formula>w*2</formula>
+      </formulas>
+      <vars>
+        <var name="w" scale="0">
+          <min>10</min>
+          <max>100</max>
+        </var>
+      </vars>
+      <var_sets>
+        <var_set ident="set1">
+          <var name="w">50</var>
+          <answer>100.0</answer>
+        </var_set>
+        <var_set ident="set2">
+          <var name="w">75</var>
+          <answer>150.0</answer>
+        </var_set>
+        <var_set ident="set3">
+          <var name="w">30</var>
+          <answer>60.0</answer>
+        </var_set>
+      </var_sets>
+    </calculated>
+  </itemproc_extension>
+</item>


### PR DESCRIPTION
This pull request adds support for parsing and converting New Quizzes calculated questions that use backtick notation for variables, in addition to the existing support for Classic Quizzes with square bracket notation. It also introduces a new test case and fixture to ensure correct handling of this format.

**Support for New Quizzes calculated questions with backtick variable notation:**

* Updated `extract_template_values` in `calculated.rb` to detect and extract variables using backtick notation (e.g., `` `w` ``) and to fall back to the original method for square bracket notation. The `extract_stimulus` method now also replaces variables based on the detected notation.

**Testing and fixtures:**

* Added a new test case to `canvas_qti_to_learnosity_converter_spec.rb` to verify correct parsing and conversion of calculated questions using backtick variable notation.
* Introduced a new fixture file, `calculated_new_quizzes.qti.xml`, representing a New Quizzes calculated question with backtick variable notation for variables.